### PR TITLE
Fix text fields

### DIFF
--- a/FCAlertView/Classes/FCAlertView.h
+++ b/FCAlertView/Classes/FCAlertView.h
@@ -172,6 +172,7 @@ typedef void (^FCTextReturnBlock)(NSString *text);
 @property (nonatomic, copy) FCTextReturnBlock textReturnBlock;
 - (void)addTextFieldWithPlaceholder:(NSString *)placeholder andTextReturnBlock:(FCTextReturnBlock)textReturn;
 - (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField andTextReturnBlock:(FCTextReturnBlock)textReturn;
+- (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField onlyNumbers:(NSNumber*)numbersOnly andTextReturnBlock:(FCTextReturnBlock)textReturn;
 
 // Color Schemes
 

--- a/FCAlertView/Classes/FCAlertView.h
+++ b/FCAlertView/Classes/FCAlertView.h
@@ -173,7 +173,7 @@ typedef void (^FCTextReturnBlock)(NSString *text);
 @property (nonatomic, copy) FCTextReturnBlock textReturnBlock;
 - (void)addTextFieldWithPlaceholder:(NSString *)placeholder andTextReturnBlock:(FCTextReturnBlock)textReturn;
 - (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField andTextReturnBlock:(FCTextReturnBlock)textReturn;
-- (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField onlyNumbers:(NSNumber*)numbersOnly andTextReturnBlock:(FCTextReturnBlock)textReturn;
+- (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField onlyNumbers:(NSNumber*)numbersOnly keyboardType:(UIKeyboardType)type andTextReturnBlock:(FCTextReturnBlock)textReturn;
 
 // Color Schemes
 
@@ -211,3 +211,4 @@ typedef void (^FCTextReturnBlock)(NSString *text);
 - (void)FCAlertDoneButtonClicked:(FCAlertView *)alertView;
 
 @end
+

--- a/FCAlertView/Classes/FCAlertView.h
+++ b/FCAlertView/Classes/FCAlertView.h
@@ -93,6 +93,7 @@
 @property NSInteger numberOfButtons;
 @property NSInteger autoHideSeconds;
 @property CGFloat cornerRadius;
+@property int maxCharacter;
 
 @property BOOL dismissOnOutsideTouch;
 @property BOOL hideAllButtons;

--- a/FCAlertView/Classes/FCAlertView.h
+++ b/FCAlertView/Classes/FCAlertView.h
@@ -171,6 +171,7 @@ typedef void (^FCActionBlock)(void);
 typedef void (^FCTextReturnBlock)(NSString *text);
 @property (nonatomic, copy) FCTextReturnBlock textReturnBlock;
 - (void)addTextFieldWithPlaceholder:(NSString *)placeholder andTextReturnBlock:(FCTextReturnBlock)textReturn;
+- (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField andTextReturnBlock:(FCTextReturnBlock)textReturn;
 
 // Color Schemes
 

--- a/FCAlertView/Classes/FCAlertView.h
+++ b/FCAlertView/Classes/FCAlertView.h
@@ -34,8 +34,8 @@
     // Customizations made to UI
     
     NSMutableArray *alertButtons;
-    NSMutableArray *alertTextFields;
-    NSMutableArray *alertTextFieldHolder;
+    NSMutableArray *alertTextFields;            //text fields in form
+    NSMutableArray *alertTextFieldsDictionaries;//Dictionaries holding text fields data
     NSInteger alertViewWithVector;
     NSString *doneTitle;
     UIImage *vectorImage;
@@ -84,9 +84,6 @@
 
 @property (nonatomic, retain) UIView *alertBackground;
 
-// AlertView TextView
-
-@property (nonatomic, retain) UITextField *textField;
 
 // AlertView Customizations
 
@@ -98,7 +95,6 @@
 @property CGFloat cornerRadius;
 
 @property BOOL dismissOnOutsideTouch;
-@property BOOL overrideForcedDismiss;
 @property BOOL hideAllButtons;
 @property BOOL hideDoneButton;
 @property BOOL avoidCustomImageTint;
@@ -175,7 +171,6 @@ typedef void (^FCActionBlock)(void);
 typedef void (^FCTextReturnBlock)(NSString *text);
 @property (nonatomic, copy) FCTextReturnBlock textReturnBlock;
 - (void)addTextFieldWithPlaceholder:(NSString *)placeholder andTextReturnBlock:(FCTextReturnBlock)textReturn;
-- (void)addTextFieldWithCustomTextField:(UITextField *)field andPlaceholder:(NSString *)placeholder andTextReturnBlock:(FCTextReturnBlock)textReturn;
 
 // Color Schemes
 
@@ -185,19 +180,12 @@ typedef void (^FCTextReturnBlock)(NSString *text);
 @property (nonatomic, retain) UIColor *alertBackgroundColor;
 
 @property (nonatomic, retain)  UIColor * doneButtonTitleColor;
-@property (nonatomic, retain)  UIFont * doneButtonCustomFont;
-@property (nonatomic, retain)  UIColor * doneButtonHighlightedBackgroundColor;
 
 @property (nonatomic, retain)  UIColor * firstButtonTitleColor;
-@property (nonatomic, retain)  UIFont * firstButtonCustomFont;
 @property (nonatomic, retain)  UIColor * firstButtonBackgroundColor;
-@property (nonatomic, retain)  UIColor * firstButtonHighlightedBackgroundColor;
 
 @property (nonatomic, retain)  UIColor * secondButtonTitleColor;
-@property (nonatomic, retain)  UIFont * secondButtonCustomFont;
 @property (nonatomic, retain)  UIColor * secondButtonBackgroundColor;
-@property (nonatomic, retain)  UIColor * secondButtonHighlightedBackgroundColor;
-
 // Preset Flat Colors
 
 @property (nonatomic, retain) UIColor * flatTurquoise;

--- a/FCAlertView/Classes/FCAlertView.m
+++ b/FCAlertView/Classes/FCAlertView.m
@@ -318,7 +318,7 @@
         alertViewFrame = CGRectMake(self.frame.size.width/2 - ((result.width - defaultSpacing)/2),
                                     self.frame.size.height/2 - ((alertViewFrame.size.height - 50 + 140)/2),
                                     result.width - defaultSpacing,
-                                    alertViewFrame.size.height + 40*alertTextFieldsDictionaries.count +20);
+                                    alertViewFrame.size.height + 60*alertTextFieldsDictionaries.count);
     else
         alertViewFrame = CGRectMake(self.frame.size.width/2 - ((result.width - defaultSpacing)/2),
                                     self.frame.size.height/2 - ((alertViewFrame.size.height - 50 + 140)/2),

--- a/FCAlertView/Classes/FCAlertView.m
+++ b/FCAlertView/Classes/FCAlertView.m
@@ -53,7 +53,6 @@
         
         alertButtons = [[NSMutableArray alloc] init];
         alertTextFields = [[NSMutableArray alloc] init];
-        alertTextFieldHolder = [[NSMutableArray alloc] init];
         
         _numberOfButtons = 0;
         _autoHideSeconds = 0;
@@ -71,10 +70,10 @@
         _hideSeparatorLineView = NO;
         _customImageScale = 1;
         _titleFont = [UIFont systemFontOfSize:18.0f weight:UIFontWeightMedium];
-        _subtitleFont = nil;
+        _subtitleFont = nil;        
         defaultSpacing = [self configureAVWidth];
         defaultHeight = [self configureAVHeight];
-        
+                
     }
     
     return self;
@@ -172,7 +171,7 @@
     
     if (_hideDoneButton || _hideAllButtons) {
         
-        if (_autoHideSeconds == 0 && !_overrideForcedDismiss) {
+        if (_autoHideSeconds == 0) {
             
             _dismissOnOutsideTouch = YES;
             
@@ -187,12 +186,12 @@
 #pragma mark - Title Validation
 -(BOOL)hasTitle {
     return (_title != nil && _title.length > 0) ||
-    (_attributedTitle != nil && _attributedTitle.length > 0);
+           (_attributedTitle != nil && _attributedTitle.length > 0);
 }
 
 -(BOOL)hasSubTitle {
     return (_subTitle != nil && _subTitle.length > 0) ||
-    (_attributedSubTitle != nil && _attributedSubTitle.length > 0);
+           (_attributedSubTitle != nil && _attributedSubTitle.length > 0);
 }
 
 #pragma mark - Touch Events
@@ -317,9 +316,9 @@
     
     if (alertTextFields.count > 0)
         alertViewFrame = CGRectMake(self.frame.size.width/2 - ((result.width - defaultSpacing)/2),
-                                    self.frame.size.height/2 - ((alertViewFrame.size.height + 45*(MIN(alertTextFields.count,4)))/2),
+                                    self.frame.size.height/2 - ((alertViewFrame.size.height - 50 + 140)/2),
                                     result.width - defaultSpacing,
-                                    alertViewFrame.size.height + 45*(MIN(alertTextFields.count,4)));
+                                    alertViewFrame.size.height + 40*alertTextFields.count +20);
     else
         alertViewFrame = CGRectMake(self.frame.size.width/2 - ((result.width - defaultSpacing)/2),
                                     self.frame.size.height/2 - ((alertViewFrame.size.height - 50 + 140)/2),
@@ -330,11 +329,11 @@
         alertViewFrame = CGRectMake(self.frame.size.width/2 - ((result.width - defaultSpacing)/2),
                                     self.frame.size.height/2 - ((alertViewFrame.size.height - 50 + 140)/2),
                                     result.width - defaultSpacing,
-                                    alertViewFrame.size.height + 50);
+                                    alertViewFrame.size.height + 40);
     
     // Landscape Orientation Width Fix
     
-    if(UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation))
+    if (UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation))
     {
         alertViewFrame = CGRectMake(self.frame.size.width/2 - (300/2),
                                     self.frame.size.height/2 - (alertViewFrame.size.height/2),
@@ -376,41 +375,8 @@
     
     descriptionLabel.numberOfLines = 0;
     descriptionLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-    
-    // HEADER VIEW - With Title & Subtitle
-    
-    UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(15.0f,
-                                                                    20.0f + (alertViewWithVector * 30),
-                                                                    alertViewFrame.size.width - 30.0f,
-                                                                    30.0f)];
-    
-    titleLabel.font = self.titleFont;
-    titleLabel.numberOfLines = 1;
-    titleLabel.textColor = self.titleColor;
-    if (_title == nil)
-        titleLabel.attributedText = self.attributedTitle;
-    else
-        titleLabel.text = self.title;
-    titleLabel.textAlignment = NSTextAlignmentCenter;
-    
-    // Re-adjusting Frames based on height of title - Requirement is to not have over 2 lines of title
-
-    CGSize size = [titleLabel.text sizeWithAttributes:@{NSFontAttributeName : titleLabel.font}];
-    if (size.width > titleLabel.bounds.size.width) {
-        titleLabel.numberOfLines = 2;
-        titleLabel.frame = CGRectMake(titleLabel.frame.origin.x, titleLabel.frame.origin.y, titleLabel.frame.size.width, 60.0f);
-        descriptionLabel.frame = CGRectMake(descriptionLabel.frame.origin.x,
-                                            descriptionLabel.frame.origin.y + 30.0f,
-                                            descriptionLabel.frame.size.width,
-                                            descriptionLabel.frame.size.height);
         
-        alertViewFrame = CGRectMake(alertViewFrame.origin.x,
-                                    alertViewFrame.origin.y,
-                                    alertViewFrame.size.width,
-                                    alertViewFrame.size.height + 30.0f);
-    }
-    
-    // Re-adjusting Frames based on height of subTitle - Requirement is to not have over 6 lines of subTitle
+    // Re-adjusting Frames based on height of text - Requirement is to not have over 6 lines of text
     
     CGSize constraint = CGSizeMake(descriptionLabel.frame.size.width, CGFLOAT_MAX);
     
@@ -419,7 +385,7 @@
                                                              options:NSStringDrawingUsesLineFragmentOrigin
                                                           attributes:@{NSFontAttributeName:descriptionLabel.font}
                                                              context:context].size;
-    
+
     CGFloat heightDiff = descriptionLabel.frame.size.height - boundingBox.height;
     
     descriptionLabel.frame = CGRectMake(descriptionLabel.frame.origin.x,
@@ -490,6 +456,21 @@
     if (alertViewWithVector)
         [alertView.layer addSublayer:fillLayer];
     
+    // HEADER VIEW - With Title & Subtitle
+    
+    UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(15.0f,
+                                                                    20.0f + (alertViewWithVector * 30),
+                                                                    alertViewFrame.size.width - 30.0f,
+                                                                    20.0f)];
+    titleLabel.font = self.titleFont;
+    titleLabel.numberOfLines = 1;
+    titleLabel.textColor = self.titleColor;
+    if (_title == nil)
+        titleLabel.attributedText = self.attributedTitle;
+    else
+        titleLabel.text = self.title;
+    titleLabel.textAlignment = NSTextAlignmentCenter;
+    
     // SEPARATOR LINE - Seperating Header View with Button View
     
     UIView* separatorLineView = [[UIView alloc] initWithFrame:CGRectMake(0,
@@ -502,56 +483,29 @@
         separatorLineView.backgroundColor = [UIColor colorWithWhite:58.0f/255.0f alpha:1.0];
     
     // TEXTFIELD VIEW - Section with TextField
-    
+    int y = descriptionLabel.frame.size.height + descriptionLabel.frame.origin.y + 10.5;
     if (alertTextFields.count > 0) {
-        
-        for (int i = 0; i < MIN(alertTextFields.count,4); i++) {
+        for (NSDictionary *alertTextField in alertTextFields) {
+            _textField = [[UITextField alloc] initWithFrame:CGRectMake(12.5, y, alertViewFrame.size.width - 25, 40)];
             
-            UITextField *tf = [[UITextField alloc] initWithFrame:CGRectMake(12.5, descriptionLabel.frame.size.height + descriptionLabel.frame.origin.y + 10.5 + 45*i, alertViewFrame.size.width - 25, 40)];
-            
-            if ([[alertTextFields objectAtIndex:i] objectForKey:@"field"] != nil &&
-                [[[alertTextFields objectAtIndex:i] objectForKey:@"field"] isKindOfClass:[UITextField class]]) {
-                
-                tf = [[alertTextFields objectAtIndex:i] objectForKey:@"field"];
-                tf.frame = CGRectMake(12.5, descriptionLabel.frame.size.height + descriptionLabel.frame.origin.y + 10.5 + 45*i, alertViewFrame.size.width - 25, 40);
-                
-            }
-            
-            if (tf.layer.cornerRadius == 0)
-                tf.layer.cornerRadius = 3.0f;
-            tf.layer.masksToBounds = YES;
-            tf.layer.borderColor = [[UIColor colorWithWhite:217.0f/255.0f alpha:1.0] CGColor];
-            
-            if (tf.layer.borderWidth == 0)
-                tf.layer.borderWidth = 1.0f;
-            
-            tf.delegate = self;
-            tf.tag = i;
-            if (tf.placeholder.length == 0 &&
-                [[alertTextFields objectAtIndex:i] objectForKey:@"placeholder"] != nil &&
-                [[[alertTextFields objectAtIndex:i] objectForKey:@"placeholder"] length] > 0)
-                tf.placeholder = [[alertTextFields objectAtIndex:i] objectForKey:@"placeholder"];
-            
+            _textField.layer.cornerRadius = 3.0f;
+            _textField.layer.masksToBounds = YES;
+            _textField.layer.borderColor = [[UIColor colorWithWhite:217.0f/255.0f alpha:1.0] CGColor];
+            _textField.layer.borderWidth = 1.0f;
+            _textField.delegate = self;
+            _textField.placeholder = [alertTextField objectForKey:@"placeholder"];
             if (self.darkTheme)
-                tf.backgroundColor = [UIColor colorWithWhite:227.0f/255.0f alpha:1.0];
+                _textField.backgroundColor = [UIColor colorWithWhite:227.0f/255.0f alpha:1.0];
             else
-                tf.backgroundColor = [UIColor whiteColor];
-            
-            if (i+1 == MIN(alertTextFields.count,4))
-                [tf setReturnKeyType:UIReturnKeyDone];
-            else
-                [tf setReturnKeyType:UIReturnKeyNext];
+                _textField.backgroundColor = [UIColor whiteColor];
             
             UIView *paddingView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 5, 20)];
-            tf.leftView = paddingView;
-            tf.leftViewMode = UITextFieldViewModeAlways;
+            _textField.leftView = paddingView;
+            _textField.leftViewMode = UITextFieldViewModeAlways;
             
-            [alertTextFieldHolder addObject:tf];
-            
-            [alertView addSubview:tf];
-            
+            [alertView addSubview:_textField];
+            y += 60;
         }
-        
     }
     
     // BUTTON(S) VIEW - Section containing all Buttons
@@ -568,9 +522,6 @@
         } else {
             doneButton.backgroundColor = _colorScheme;
         }
-        
-        if (_doneButtonHighlightedBackgroundColor)
-            [doneButton setBackgroundImage:[self imageWithColor:_doneButtonHighlightedBackgroundColor] forState:UIControlStateHighlighted];
         
         doneButton.frame = CGRectMake(0,
                                       alertViewFrame.size.height - 45,
@@ -590,8 +541,6 @@
         [doneButton addTarget:self action:@selector(btnTouched) forControlEvents:UIControlEventTouchDown];
         [doneButton addTarget:self action:@selector(btnReleased) forControlEvents:UIControlEventTouchDragExit];
         doneButton.titleLabel.font = [UIFont systemFontOfSize:18.0f weight:UIFontWeightMedium];
-        if (self.doneButtonCustomFont)
-            doneButton.titleLabel.font = self.doneButtonCustomFont;
         if (_colorScheme != nil || _darkTheme)
             doneButton.tintColor = [UIColor whiteColor];
         if (self.doneButtonTitleColor != nil)
@@ -613,9 +562,6 @@
             doneButton.backgroundColor = _colorScheme;
         }
         
-        if (_doneButtonHighlightedBackgroundColor)
-            [doneButton setBackgroundImage:[self imageWithColor:_doneButtonHighlightedBackgroundColor] forState:UIControlStateHighlighted];
-        
         doneButton.frame = CGRectMake(alertViewFrame.size.width/2,
                                       alertViewFrame.size.height - 45,
                                       alertViewFrame.size.width/2,
@@ -634,8 +580,6 @@
         [doneButton addTarget:self action:@selector(btnTouched) forControlEvents:UIControlEventTouchDown];
         [doneButton addTarget:self action:@selector(btnReleased) forControlEvents:UIControlEventTouchDragExit];
         doneButton.titleLabel.font = [UIFont systemFontOfSize:16.0f weight:UIFontWeightMedium];
-        if (self.doneButtonCustomFont)
-            doneButton.titleLabel.font = self.doneButtonCustomFont;
         if (_colorScheme != nil || _darkTheme)
             doneButton.tintColor = [UIColor whiteColor];
         if (self.doneButtonTitleColor != nil)
@@ -649,9 +593,6 @@
             otherButton.backgroundColor = [UIColor colorWithWhite:78.0f/255.0f alpha:1.0];
         if (self.firstButtonBackgroundColor != nil)
             otherButton.backgroundColor = self.firstButtonBackgroundColor;
-        
-        if (_firstButtonHighlightedBackgroundColor)
-            [otherButton setBackgroundImage:[self imageWithColor:_firstButtonHighlightedBackgroundColor] forState:UIControlStateHighlighted];
         
         otherButton.frame = CGRectMake(0,
                                        alertViewFrame.size.height - 45,
@@ -677,8 +618,6 @@
         [otherButton addTarget:self action:@selector(btnTouched) forControlEvents:UIControlEventTouchDown];
         [otherButton addTarget:self action:@selector(btnReleased) forControlEvents:UIControlEventTouchDragExit];
         otherButton.titleLabel.font = [UIFont systemFontOfSize:16.0f weight:UIFontWeightRegular];
-        if (self.firstButtonCustomFont)
-            otherButton.titleLabel.font = self.firstButtonCustomFont;
         otherButton.tintColor = self.colorScheme;
         if (self.colorScheme == nil && _darkTheme)
             otherButton.tintColor = [UIColor whiteColor];
@@ -730,9 +669,6 @@
         if (self.firstButtonBackgroundColor != nil)
             firstButton.backgroundColor = self.firstButtonBackgroundColor;
         
-        if (_firstButtonHighlightedBackgroundColor)
-            [firstButton setBackgroundImage:[self imageWithColor:_firstButtonHighlightedBackgroundColor] forState:UIControlStateHighlighted];
-        
         firstButton.frame = CGRectMake(0,
                                        alertViewFrame.size.height - 135,
                                        alertViewFrame.size.width,
@@ -758,8 +694,6 @@
         [firstButton addTarget:self action:@selector(btnTouched) forControlEvents:UIControlEventTouchDown];
         [firstButton addTarget:self action:@selector(btnReleased) forControlEvents:UIControlEventTouchDragExit];
         firstButton.titleLabel.font = [UIFont systemFontOfSize:16.0f weight:UIFontWeightRegular];
-        if (self.firstButtonCustomFont)
-            firstButton.titleLabel.font = self.firstButtonCustomFont;
         firstButton.tintColor = self.colorScheme;
         if (self.colorScheme == nil && _darkTheme)
             firstButton.tintColor = [UIColor whiteColor];
@@ -778,9 +712,6 @@
             secondButton.backgroundColor = [UIColor colorWithWhite:78.0f/255.0f alpha:1.0];
         if (self.secondButtonBackgroundColor != nil)
             secondButton.backgroundColor = self.secondButtonBackgroundColor;
-        
-        if (_secondButtonHighlightedBackgroundColor)
-            [secondButton setBackgroundImage:[self imageWithColor:_secondButtonHighlightedBackgroundColor] forState:UIControlStateHighlighted];
         
         secondButton.frame = CGRectMake(0,
                                         alertViewFrame.size.height - 90,
@@ -806,8 +737,6 @@
         [secondButton addTarget:self action:@selector(btnTouched) forControlEvents:UIControlEventTouchDown];
         [secondButton addTarget:self action:@selector(btnReleased) forControlEvents:UIControlEventTouchDragExit];
         secondButton.titleLabel.font = [UIFont systemFontOfSize:16.0f weight:UIFontWeightRegular];
-        if (self.secondButtonCustomFont)
-            secondButton.titleLabel.font = self.secondButtonCustomFont;
         secondButton.tintColor = self.colorScheme;
         if (self.colorScheme == nil && _darkTheme)
             secondButton.tintColor = [UIColor whiteColor];
@@ -829,9 +758,6 @@
             doneButton.backgroundColor = _colorScheme;
         }
         
-        if (_doneButtonHighlightedBackgroundColor)
-            [doneButton setBackgroundImage:[self imageWithColor:_doneButtonHighlightedBackgroundColor] forState:UIControlStateHighlighted];
-        
         doneButton.frame = CGRectMake(0,
                                       alertViewFrame.size.height - 45,
                                       alertViewFrame.size.width,
@@ -850,8 +776,6 @@
         [doneButton addTarget:self action:@selector(btnTouched) forControlEvents:UIControlEventTouchDown];
         [doneButton addTarget:self action:@selector(btnReleased) forControlEvents:UIControlEventTouchDragExit];
         doneButton.titleLabel.font = [UIFont systemFontOfSize:18.0f weight:UIFontWeightMedium];
-        if (self.doneButtonCustomFont)
-            doneButton.titleLabel.font = self.doneButtonCustomFont;
         if (_colorScheme != nil || _darkTheme)
             doneButton.tintColor = [UIColor whiteColor];
         if (self.doneButtonTitleColor != nil)
@@ -959,7 +883,7 @@
     }
     
     CGFloat vectorSize = 30.0f * MIN(2, _customImageScale);
-    
+
     alertViewVector.frame = CGRectMake(alertViewContents.frame.size.width/2 - (vectorSize/2),
                                        -(vectorSize/2) - 0.5,
                                        vectorSize,
@@ -1023,10 +947,8 @@
     
     // ADDING RATING SYSTEM
     
-    UITextField *tf = [alertTextFieldHolder firstObject];
-    
     ratingController = [[UIView alloc] initWithFrame:CGRectMake(20,
-                                                                descriptionLevel + descriptionLabelFrames.size.height + 32.5 + 15+ (MAX(1, MIN(alertTextFields.count,4))*(tf.frame.size.height + 7.5)),
+                                                                descriptionLevel + descriptionLabelFrames.size.height + 32.5 + 15+ (MIN(1, alertTextFields.count)*(_textField.frame.size.height + 7.5)),
                                                                 alertViewFrame.size.width - 40,
                                                                 40)];
     
@@ -1115,22 +1037,6 @@
     
     [self showAlertView];
     
-}
-
-#pragma mark - Create Image with Color
-
-- (UIImage *)imageWithColor:(UIColor *)color {
-    CGRect rect = CGRectMake(0.0f, 0.0f, 1.0f, 1.0f);
-    UIGraphicsBeginImageContext(rect.size);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    
-    CGContextSetFillColorWithColor(context, [color CGColor]);
-    CGContextFillRect(context, rect);
-    
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    
-    return image;
 }
 
 #pragma mark - Getting Resources from Bundle
@@ -1262,7 +1168,7 @@
 - (void) showAlertWithTitle:(NSString *)title withSubtitle:(NSString *)subTitle withCustomImage:(UIImage *)image withDoneButtonTitle:(NSString *)done andButtons:(NSArray *)buttons{
     
     [self setAlertViewAttributes:title withSubtitle:subTitle withCustomImage:image withDoneButtonTitle:done andButtons:buttons];
-    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    UIWindow *window = [UIApplication sharedApplication].windows.lastObject;
     
     // Blur Effect
     if (_blurBackground && NSClassFromString(@"UIVisualEffectView") != nil) {
@@ -1284,7 +1190,7 @@
     
     self.attributedTitle = title;
     [self setAlertViewAttributes:nil withSubtitle:subTitle withCustomImage:image withDoneButtonTitle:done andButtons:buttons];
-    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    UIWindow *window = [UIApplication sharedApplication].windows.lastObject;
     
     // Blur Effect
     if (_blurBackground && NSClassFromString(@"UIVisualEffectView") != nil) {
@@ -1305,7 +1211,7 @@
     
     self.attributedSubTitle = subTitle;
     [self setAlertViewAttributes:title withSubtitle:nil withCustomImage:image withDoneButtonTitle:done andButtons:buttons];
-    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    UIWindow *window = [UIApplication sharedApplication].windows.lastObject;
     
     // Blur Effect
     if (_blurBackground && NSClassFromString(@"UIVisualEffectView") != nil) {
@@ -1327,7 +1233,7 @@
     self.attributedTitle = title;
     self.attributedSubTitle = subTitle;
     [self setAlertViewAttributes:nil withSubtitle:nil withCustomImage:image withDoneButtonTitle:done andButtons:buttons];
-    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    UIWindow *window = [UIApplication sharedApplication].windows.lastObject;
     
     // Blur Effect
     if (_blurBackground && NSClassFromString(@"UIVisualEffectView") != nil) {
@@ -1541,7 +1447,7 @@
                 }];
             } else {
                 id<FCAlertViewDelegate> strongDelegate = self.delegate;
-                
+
                 if ([strongDelegate respondsToSelector:@selector(FCAlertViewDismissed:)]) {
                     [strongDelegate FCAlertViewDismissed:self];
                 }
@@ -1586,19 +1492,6 @@
     
     id<FCAlertViewDelegate> strongDelegate = self.delegate;
     
-    // Return Text from TextField to Block
-    
-    for (int i = 0; i < alertTextFields.count; i ++) {
-        
-        FCTextReturnBlock textReturnBlock = [[alertTextFields objectAtIndex:i] objectForKey:@"action"];
-        UITextField *tf = [alertTextFieldHolder objectAtIndex:i];
-        if (textReturnBlock)
-            textReturnBlock(tf.text);
-        
-    }
-    
-    // Handling Button Block
-    
     UIButton *clickedButton = (UIButton*)sender;
     
     NSDictionary *btnDict = [alertButtons objectAtIndex:[sender tag]];
@@ -1614,6 +1507,12 @@
     if ([strongDelegate respondsToSelector:@selector(FCAlertView:clickedButtonIndex:buttonTitle:)]) {
         [strongDelegate FCAlertView:self clickedButtonIndex:[sender tag] buttonTitle:clickedButton.titleLabel.text];
     }
+    
+    // Rertun Text from TextField to Block
+    
+    FCTextReturnBlock textReturnBlock = [[alertTextFields firstObject] objectForKey:@"action"];
+    if (textReturnBlock)
+        textReturnBlock(_textField.text);
     
     // Return Rating from Rating Controller
     
@@ -1642,27 +1541,19 @@
 
 - (void) donePressed {
     
-    id<FCAlertViewDelegate> strongDelegate = self.delegate;
-
-    // Return Text from TextField to Block
-    
-    for (int i = 0; i < alertTextFields.count; i ++) {
-        
-        FCTextReturnBlock textReturnBlock = [[alertTextFields objectAtIndex:i] objectForKey:@"action"];
-        UITextField *tf = [alertTextFieldHolder objectAtIndex:i];
-        if (textReturnBlock)
-            textReturnBlock(tf.text);
-        
-    }
-    
-    // Handling Done Button Block
-
     if (self.doneBlock)
         self.doneBlock();
+    
+    id<FCAlertViewDelegate> strongDelegate = self.delegate;
     
     if ([strongDelegate respondsToSelector:@selector(FCAlertDoneButtonClicked:)]) {
         [strongDelegate FCAlertDoneButtonClicked:self];
     }
+    
+    FCTextReturnBlock textReturnBlock = [[alertTextFields firstObject] objectForKey:@"action"];
+    
+    if (textReturnBlock)
+        textReturnBlock(_textField.text);
     
     // Return Rating from Rating Controller
     
@@ -1705,22 +1596,6 @@
     
 }
 
-- (void)addTextFieldWithCustomTextField:(UITextField *)field andPlaceholder:(NSString *)placeholder andTextReturnBlock:(FCTextReturnBlock)textReturn {
-    
-    if (placeholder == nil)
-        placeholder = @"";
-    
-    if (textReturn != nil)
-        [alertTextFields addObject:@{@"field" : field,
-                                     @"placeholder" : placeholder,
-                                     @"action" : textReturn}];
-    else
-        [alertTextFields addObject:@{@"field" : field,
-                                     @"placeholder" : placeholder,
-                                     @"action" : @0}];
-    
-}
-
 - (void)textFieldDidBeginEditing:(UITextField *)textField {
     
     currentAVCFrames = alertViewContents.frame;
@@ -1751,12 +1626,7 @@
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {
     
-    if (textField.tag+1 == alertTextFieldHolder.count) {
-        [textField endEditing:YES];
-    } else {
-        UITextField *tf = [alertTextFieldHolder objectAtIndex:(textField.tag+1)];
-        [tf becomeFirstResponder];
-    }
+    [textField endEditing:YES];
     
     return TRUE;
 }

--- a/FCAlertView/Classes/FCAlertView.m
+++ b/FCAlertView/Classes/FCAlertView.m
@@ -496,9 +496,10 @@
             tf.layer.borderColor = [[UIColor colorWithWhite:217.0f/255.0f alpha:1.0] CGColor];
             tf.layer.borderWidth = 1.0f;
             tf.delegate = self;
+            tf.keyboardType = [[alertTextField objectForKey:@"keyboardType"] intValue];
             tf.placeholder = [alertTextField objectForKey:@"placeholder"];
             NSNumber *secureField = [alertTextField objectForKey:@"secureField"];
-            tf.secureTextEntry = [secureField boolValue] ;
+            tf.secureTextEntry = [secureField boolValue];
             
             if (self.darkTheme)
                 tf.backgroundColor = [UIColor colorWithWhite:227.0f/255.0f alpha:1.0];
@@ -1598,14 +1599,14 @@
 #pragma mark - Adding Alert TextField Block Method
 
 - (void)addTextFieldWithPlaceholder:(NSString *)placeholder andTextReturnBlock:(FCTextReturnBlock)textReturn {
-    [self addTextFieldWithPlaceholder:placeholder secure:[NSNumber numberWithBool:false] onlyNumbers:[NSNumber numberWithBool:false] andTextReturnBlock:textReturn];
+    [self addTextFieldWithPlaceholder:placeholder secure:[NSNumber numberWithBool:false] onlyNumbers:[NSNumber numberWithBool:false] keyboardType:UIKeyboardTypeDefault andTextReturnBlock:textReturn];
 }
 
 - (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField andTextReturnBlock:(FCTextReturnBlock)textReturn{
-    [self addTextFieldWithPlaceholder:placeholder secure:secureField onlyNumbers:[NSNumber numberWithBool:false] andTextReturnBlock:textReturn];
+    [self addTextFieldWithPlaceholder:placeholder secure:secureField onlyNumbers:[NSNumber numberWithBool:false] keyboardType:UIKeyboardTypeDefault andTextReturnBlock:textReturn];
 }
 
-- (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField onlyNumbers:(NSNumber*)numbersOnly andTextReturnBlock:(FCTextReturnBlock)textReturn
+- (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField onlyNumbers:(NSNumber*)numbersOnly keyboardType:(UIKeyboardType)type andTextReturnBlock:(FCTextReturnBlock)textReturn
 {
     if (secureField == nil){
         secureField = [NSNumber numberWithBool:false];
@@ -1614,16 +1615,19 @@
     if (numbersOnly == nil) {
         numbersOnly = [NSNumber numberWithBool:false];
     }
+    
     if (textReturn != nil){
         [alertTextFieldsDictionaries addObject:@{@"placeholder" : placeholder,
                                                  @"action":textReturn,
                                                  @"secureField" : secureField,
-                                                 @"numbersOnly" : numbersOnly}];
+                                                 @"numbersOnly" : numbersOnly,
+                                                 @"keyboardType": [NSNumber numberWithInt:type]}];
     }else{
         [alertTextFieldsDictionaries addObject:@{@"placeholder" : placeholder,
                                                  @"action":@0,
                                                  @"secureField" : secureField,
-                                                 @"numbersOnly" : numbersOnly}];
+                                                 @"numbersOnly" : numbersOnly,
+                                                 @"keyboardType": [NSNumber numberWithInt:UIKeyboardTypeDefault]}];
     }
 }
 
@@ -1810,3 +1814,4 @@
 }
 
 @end
+

--- a/FCAlertView/Classes/FCAlertView.m
+++ b/FCAlertView/Classes/FCAlertView.m
@@ -1667,18 +1667,20 @@
     int position = [alertTextFields indexOfObject:textField];
     NSNumber *numbersOnly = [[alertTextFieldsDictionaries objectAtIndex:position] valueForKey:@"numbersOnly"];
     
-    if (numbersOnly != nil && [numbersOnly boolValue]) {
-        NSCharacterSet *myCharSet = [NSCharacterSet decimalDigitCharacterSet];
-        for (int i = 0; i < [string length]; i++) {
-            unichar c = [string characterAtIndex:i];
-            if ([myCharSet characterIsMember:c]) {
-                return YES;
+    if (range.length > 0){
+        return YES;
+    }else{
+        if (numbersOnly != nil && [numbersOnly boolValue]) {
+            NSCharacterSet *myCharSet = [NSCharacterSet decimalDigitCharacterSet];
+            for (int i = 0; i < [string length]; i++) {
+                unichar c = [string characterAtIndex:i];
+                if ([myCharSet characterIsMember:c]) {
+                    return YES;
+                }
             }
         }
     }
-    else {
-        return YES;
-    }
+    return NO;
 }
 
 #pragma mark - Rating System Trigger Methods

--- a/FCAlertView/Classes/FCAlertView.m
+++ b/FCAlertView/Classes/FCAlertView.m
@@ -1676,18 +1676,21 @@
     
     if (range.length > 0){
         return YES;
-    }else if (textField.text.length < _maxCharacter){
+    }else if((textField.text.length >= _maxCharacter)) {
+        return NO;
+    }
+    else{
         if (numbersOnly != nil && [numbersOnly boolValue]) {
             NSCharacterSet *myCharSet = [NSCharacterSet decimalDigitCharacterSet];
             for (int i = 0; i < [string length]; i++) {
                 unichar c = [string characterAtIndex:i];
-                if ([myCharSet characterIsMember:c]) {
-                    return YES;
+                if (![myCharSet characterIsMember:c]) {
+                    return NO;
                 }
             }
         }
     }
-    return NO;
+    return YES;
 }
 
 #pragma mark - Rating System Trigger Methods

--- a/FCAlertView/Classes/FCAlertView.m
+++ b/FCAlertView/Classes/FCAlertView.m
@@ -71,7 +71,7 @@
         _hideSeparatorLineView = NO;
         _customImageScale = 1;
         _titleFont = [UIFont systemFontOfSize:18.0f weight:UIFontWeightMedium];
-        _subtitleFont = nil;        
+        _subtitleFont = nil;
         defaultSpacing = [self configureAVWidth];
         defaultHeight = [self configureAVHeight];
     }
@@ -186,12 +186,12 @@
 #pragma mark - Title Validation
 -(BOOL)hasTitle {
     return (_title != nil && _title.length > 0) ||
-           (_attributedTitle != nil && _attributedTitle.length > 0);
+    (_attributedTitle != nil && _attributedTitle.length > 0);
 }
 
 -(BOOL)hasSubTitle {
     return (_subTitle != nil && _subTitle.length > 0) ||
-           (_attributedSubTitle != nil && _attributedSubTitle.length > 0);
+    (_attributedSubTitle != nil && _attributedSubTitle.length > 0);
 }
 
 #pragma mark - Touch Events
@@ -375,7 +375,7 @@
     
     descriptionLabel.numberOfLines = 0;
     descriptionLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-        
+    
     // Re-adjusting Frames based on height of text - Requirement is to not have over 6 lines of text
     
     CGSize constraint = CGSizeMake(descriptionLabel.frame.size.width, CGFLOAT_MAX);
@@ -385,7 +385,7 @@
                                                              options:NSStringDrawingUsesLineFragmentOrigin
                                                           attributes:@{NSFontAttributeName:descriptionLabel.font}
                                                              context:context].size;
-
+    
     CGFloat heightDiff = descriptionLabel.frame.size.height - boundingBox.height;
     
     descriptionLabel.frame = CGRectMake(descriptionLabel.frame.origin.x,
@@ -889,7 +889,7 @@
     }
     
     CGFloat vectorSize = 30.0f * MIN(2, _customImageScale);
-
+    
     alertViewVector.frame = CGRectMake(alertViewContents.frame.size.width/2 - (vectorSize/2),
                                        -(vectorSize/2) - 0.5,
                                        vectorSize,
@@ -1453,7 +1453,7 @@
                 }];
             } else {
                 id<FCAlertViewDelegate> strongDelegate = self.delegate;
-
+                
                 if ([strongDelegate respondsToSelector:@selector(FCAlertViewDismissed:)]) {
                     [strongDelegate FCAlertViewDismissed:self];
                 }
@@ -1633,7 +1633,7 @@
     
     [UIView animateWithDuration:0.30 delay:0.0 options:UIViewAnimationOptionCurveEaseOut animations:^{
         alertViewContents.frame = CGRectMake(currentAVCFrames.origin.x,
-                                             currentAVCFrames.origin.y - 80,
+                                             currentAVCFrames.origin.y - 120,
                                              currentAVCFrames.size.width,
                                              currentAVCFrames.size.height);
     } completion:nil];
@@ -1644,9 +1644,11 @@
 
 - (void)textFieldDidEndEditing:(UITextField *)textField {
     
+    currentAVCFrames = alertViewContents.frame;
+    
     [UIView animateWithDuration:0.30 delay:0.0 options:UIViewAnimationOptionCurveEaseOut animations:^{
         alertViewContents.frame = CGRectMake(currentAVCFrames.origin.x,
-                                             currentAVCFrames.origin.y,
+                                             currentAVCFrames.origin.y + 120,
                                              currentAVCFrames.size.width,
                                              currentAVCFrames.size.height);
     } completion:nil];
@@ -1807,3 +1809,4 @@
 }
 
 @end
+

--- a/FCAlertView/Classes/FCAlertView.m
+++ b/FCAlertView/Classes/FCAlertView.m
@@ -1597,31 +1597,33 @@
 #pragma mark - Adding Alert TextField Block Method
 
 - (void)addTextFieldWithPlaceholder:(NSString *)placeholder andTextReturnBlock:(FCTextReturnBlock)textReturn {
-    
-    if (textReturn != nil)
-        [alertTextFieldsDictionaries addObject:@{@"placeholder" : placeholder,
-                                     @"action" : textReturn}];
-    else
-        [alertTextFieldsDictionaries addObject:@{@"placeholder" : placeholder,
-                                     @"action" : @0}];
-    
+    [self addTextFieldWithPlaceholder:placeholder secure:[NSNumber numberWithBool:false] onlyNumbers:[NSNumber numberWithBool:false] andTextReturnBlock:textReturn];
 }
+
 - (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField andTextReturnBlock:(FCTextReturnBlock)textReturn{
-    
+    [self addTextFieldWithPlaceholder:placeholder secure:secureField onlyNumbers:[NSNumber numberWithBool:false] andTextReturnBlock:textReturn];
+}
+
+- (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField onlyNumbers:(NSNumber*)numbersOnly andTextReturnBlock:(FCTextReturnBlock)textReturn
+{
     if (secureField == nil){
         secureField = [NSNumber numberWithBool:false];
+    }
+    
+    if (numbersOnly == nil) {
+        numbersOnly = [NSNumber numberWithBool:false];
     }
     if (textReturn != nil){
         [alertTextFieldsDictionaries addObject:@{@"placeholder" : placeholder,
                                                  @"action":textReturn,
-                                                 @"secureField" : secureField}];
+                                                 @"secureField" : secureField,
+                                                 @"numbersOnly" : numbersOnly}];
     }else{
         [alertTextFieldsDictionaries addObject:@{@"placeholder" : placeholder,
                                                  @"action":@0,
-                                                 @"secureField" : secureField}];
+                                                 @"secureField" : secureField,
+                                                 @"numbersOnly" : numbersOnly}];
     }
-    
-    
 }
 
 
@@ -1658,6 +1660,25 @@
     [textField endEditing:YES];
     
     return TRUE;
+}
+
+-(BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
+{
+    int position = [alertTextFields indexOfObject:textField];
+    NSNumber *numbersOnly = [[alertTextFieldsDictionaries objectAtIndex:position] valueForKey:@"numbersOnly"];
+    
+    if (numbersOnly != nil && [numbersOnly boolValue]) {
+        NSCharacterSet *myCharSet = [NSCharacterSet decimalDigitCharacterSet];
+        for (int i = 0; i < [string length]; i++) {
+            unichar c = [string characterAtIndex:i];
+            if ([myCharSet characterIsMember:c]) {
+                return YES;
+            }
+        }
+    }
+    else {
+        return YES;
+    }
 }
 
 #pragma mark - Rating System Trigger Methods

--- a/FCAlertView/Classes/FCAlertView.m
+++ b/FCAlertView/Classes/FCAlertView.m
@@ -1150,8 +1150,8 @@
     // Adding Alert
     
     [self setAlertViewAttributes:title withSubtitle:subTitle withCustomImage:image withDoneButtonTitle:done andButtons:buttons];
-    [view.view.window addSubview:self];
-    
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] endEditing:YES];
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] addSubview:self];
 }
 
 - (void) showAlertInWindow:(UIWindow *)window withTitle:(NSString *)title withSubtitle:(NSString *)subTitle withCustomImage:(UIImage *)image withDoneButtonTitle:(NSString *)done andButtons:(NSArray *)buttons {
@@ -1169,8 +1169,8 @@
     // Adding Alert
     
     [self setAlertViewAttributes:title withSubtitle:subTitle withCustomImage:image withDoneButtonTitle:done andButtons:buttons];
-    [window addSubview:self];
-    
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] endEditing:YES];
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] addSubview:self];
 }
 
 - (void) showAlertWithTitle:(NSString *)title withSubtitle:(NSString *)subTitle withCustomImage:(UIImage *)image withDoneButtonTitle:(NSString *)done andButtons:(NSArray *)buttons{
@@ -1189,8 +1189,8 @@
     
     // Adding Alert
     
-    [window addSubview:self];
-    [window bringSubviewToFront:self];
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] endEditing:YES];
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] addSubview:self];
     
 }
 
@@ -1211,8 +1211,8 @@
     
     // Adding Alert
     
-    [window addSubview:self];
-    [window bringSubviewToFront:self];
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] endEditing:YES];
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] addSubview:self];
 }
 
 - (void) showAlertWithTitle:(NSString *)title withAttributedSubtitle:(NSAttributedString *)subTitle withCustomImage:(UIImage *)image withDoneButtonTitle:(NSString *)done andButtons:(NSArray *)buttons {
@@ -1232,8 +1232,8 @@
     
     // Adding Alert
     
-    [window addSubview:self];
-    [window bringSubviewToFront:self];
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] endEditing:YES];
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] addSubview:self];
 }
 
 - (void) showAlertWithAttributedTitle:(NSAttributedString *)title withAttributedSubtitle:(NSAttributedString *)subTitle withCustomImage:(UIImage *)image withDoneButtonTitle:(NSString *)done andButtons:(NSArray *)buttons {
@@ -1254,8 +1254,8 @@
     
     // Adding Alert
     
-    [window addSubview:self];
-    [window bringSubviewToFront:self];
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] endEditing:YES];
+    [[[UIApplication sharedApplication].windows objectAtIndex:0] addSubview:self];
 }
 
 

--- a/FCAlertView/Classes/FCAlertView.m
+++ b/FCAlertView/Classes/FCAlertView.m
@@ -496,6 +496,9 @@
             tf.layer.borderWidth = 1.0f;
             tf.delegate = self;
             tf.placeholder = [alertTextField objectForKey:@"placeholder"];
+            NSNumber *secureField = [alertTextField objectForKey:@"secureField"];
+            tf.secureTextEntry = [secureField boolValue] ;
+            
             if (self.darkTheme)
                 tf.backgroundColor = [UIColor colorWithWhite:227.0f/255.0f alpha:1.0];
             else
@@ -1603,6 +1606,24 @@
                                      @"action" : @0}];
     
 }
+- (void)addTextFieldWithPlaceholder:(NSString *)placeholder secure:(NSNumber*)secureField andTextReturnBlock:(FCTextReturnBlock)textReturn{
+    
+    if (secureField == nil){
+        secureField = [NSNumber numberWithBool:false];
+    }
+    if (textReturn != nil){
+        [alertTextFieldsDictionaries addObject:@{@"placeholder" : placeholder,
+                                                 @"action":textReturn,
+                                                 @"secureField" : secureField}];
+    }else{
+        [alertTextFieldsDictionaries addObject:@{@"placeholder" : placeholder,
+                                                 @"action":@0,
+                                                 @"secureField" : secureField}];
+    }
+    
+    
+}
+
 
 - (void)textFieldDidBeginEditing:(UITextField *)textField {
     

--- a/FCAlertView/Classes/FCAlertView.m
+++ b/FCAlertView/Classes/FCAlertView.m
@@ -72,6 +72,7 @@
         _customImageScale = 1;
         _titleFont = [UIFont systemFontOfSize:18.0f weight:UIFontWeightMedium];
         _subtitleFont = nil;
+        _maxCharacter = 20;
         defaultSpacing = [self configureAVWidth];
         defaultHeight = [self configureAVHeight];
     }
@@ -1671,7 +1672,7 @@
     
     if (range.length > 0){
         return YES;
-    }else{
+    }else if (textField.text.length < _maxCharacter){
         if (numbersOnly != nil && [numbersOnly boolValue]) {
             NSCharacterSet *myCharSet = [NSCharacterSet decimalDigitCharacterSet];
             for (int i = 0; i < [string length]; i++) {
@@ -1809,4 +1810,3 @@
 }
 
 @end
-


### PR DESCRIPTION
Fixed a bug showing only one text field when adding more then one with 
```
[alert addTextFieldWithPlaceholder:@"Email Address" andTextReturnBlock:^(NSString *text) {
    NSLog(@"The Email Address is: %@", text); // Do what you'd like with the text returned from the field
}];
```